### PR TITLE
Signature calc with __TMP_FOLDER

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -789,7 +789,7 @@ class PDFDoc extends Buffer {
 
             // Calculate the signature and remove the temporary file
             $certificate = $_signature->get_certificate();
-            $signature_contents = PDFUtilFnc::calculate_pkcs7_signature($temp_filename, $certificate['cert'], $certificate['pkey']);
+            $signature_contents = PDFUtilFnc::calculate_pkcs7_signature($temp_filename, $certificate['cert'], $certificate['pkey'], __TMP_FOLDER);
             unlink($temp_filename);
 
             // Then restore the contents field


### PR DESCRIPTION
PHP 8 does not like creating temporary files in system's temp folder. A notice is issued: "tempnam(): file created in the system's temporary directory".
This fix passes existing constant __TMP_FOLDER to PDFUtilFnc::calculate_pkcs7_signature() function. This fix prevents the notice above.