### PR TITLE
Fix Uninitialized string offset -1

### DIFF
--- a/src/PDFObjectParser.php
+++ b/src/PDFObjectParser.php
@@ -217,12 +217,12 @@
             $n_parenthesis = 1;
             while ($this->_c !== false) {
                 $this->nextchar();
-                if (($this->_c === ')') && ($token[strlen($token) - 1] !== '\\')) {
+                if (($this->_c === ')') && (!strlen($token) || ($token[strlen($token) - 1] !== '\\'))) {
                     $n_parenthesis--;
                     if ($n_parenthesis == 0)
                         break;
                 } else {
-                    if (($this->_c === '(') && ($token[strlen($token) - 1] !== '\\')) {
+                    if (($this->_c === '(') && (!strlen($token) || ($token[strlen($token) - 1] !== '\\'))) {
                         $n_parenthesis++;
                     }
                     $token .= $this->_c;


### PR DESCRIPTION
```
Uninitialized string offset -1

/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFObjectParser.php:220
/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFObjectParser.php:274
/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFObjectParser.php:363
/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFObjectParser.php:395
/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFObjectParser.php:345
/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFObjectParser.php:392
/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFObjectParser.php:150
/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFObjectParser.php:157
/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFUtilFnc.php:52
/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFUtilFnc.php:343
/home/runner/work/FPDF-1/FPDF-1/vendor/ddn/sapp/src/PDFUtilFnc.php:379
```

Try those pdfs
[ex.pdf](https://github.com/dealfonso/sapp/files/9956151/ex.pdf)
[test_protection.pdf](https://github.com/dealfonso/sapp/files/9956155/test_protection.pdf)

After this change `encrypted documents are not fully supported; maybe you cannot get the expected results` is displayed as expected

```
Error info at PDFDoc.php:151: encrypted documents are not fully supported; maybe you cannot get the expected results
```
