### PR TITLE
Fix Call to a member function get_keys on bool

### DIFF
--- a/src/PDFObject.php
+++ b/src/PDFObject.php
@@ -21,6 +21,7 @@
 
 namespace ddn\sapp;
 
+use ddn\sapp\pdfvalue\PDFValue;
 use ddn\sapp\pdfvalue\PDFValueObject;
 use ddn\sapp\pdfvalue\PDFValueSimple;
 use \ArrayAccess;
@@ -73,7 +74,7 @@ class PDFObject implements ArrayAccess {
     }
 
     public function get_keys() {
-        return $this->_value->get_keys();
+        return is_a($this->_value, PDFValue::class) ? $this->_value->get_keys() : false;
     }
 
     public function set_oid($oid) {


### PR DESCRIPTION
Maybe this is a bug, I'm getting
```
PHP Fatal error:  Uncaught Error: Call to a member function get_keys() on bool in PDFObject.php:76
```
It is because `$_value` on `PDFObject` is not always an instance of `PDFValue`
https://github.com/dealfonso/sapp/blob/61960ae449be7b86d47a625bab625b26db8e6ee3/src/pdfvalue/PDFValue.php#L67-L69

Is there a better solution?
