### PR TITLE
remove whitespace in PDF version

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: [ "https://paypal.me/caralla" ] 

--- a/README.md
+++ b/README.md
@@ -175,12 +175,15 @@ else {
         if ($obj === false)
             fwrite(STDERR, "failed to parse file " . $argv[1]);
         else {
-            $obj->set_signature_certificate($argv[3], $password);
-            $docsigned = $obj->to_pdf_file_s();
-            if ($docsigned === false)
-                fwrite(STDERR, "could not sign the document");
-            else
-                echo $docsigned;
+            if (!$obj->set_signature_certificate($argv[2], $password)) {
+                fwrite(STDERR, "the certificate is not valid");
+            } else {
+                $docsigned = $obj->to_pdf_file_s();
+                if ($docsigned === false)
+                    fwrite(STDERR, "could not sign the document");
+                else
+                    echo $docsigned;
+            }
         }
     }
 }
@@ -205,12 +208,15 @@ _* the code related to the position in which the signature and the image appear 
 ```php
 ...
 $obj->set_signature_appearance(0, [ $p_x, $p_y, $p_x + $i_w, $p_y + $i_h ], $image);
-$obj->set_signature_certificate($argv[3], $password);
-$docsigned = $obj->to_pdf_file_s();
-if ($docsigned === false)
-    fwrite(STDERR, "could not sign the document");
-else
-    echo $docsigned;
+if (!$obj->set_signature_certificate($argv[3], $password)) {
+    fwrite(STDERR, "the certificate is not valid");
+} else {
+    $docsigned = $obj->to_pdf_file_s();
+    if ($docsigned === false)
+        fwrite(STDERR, "could not sign the document");
+    else
+        echo $docsigned;
+}
 ...
 ```
 

--- a/pdfsign.php
+++ b/pdfsign.php
@@ -42,12 +42,15 @@ else {
         if ($obj === false)
             fwrite(STDERR, "failed to parse file " . $argv[1]);
         else {
-            $obj->set_signature_certificate($argv[2], $password);
-            $docsigned = $obj->to_pdf_file_s();
-            if ($docsigned === false)
-                fwrite(STDERR, "could not sign the document");
-            else
-                echo $docsigned;
+            if (!$obj->set_signature_certificate($argv[2], $password)) {
+                fwrite(STDERR, "the certificate is not valid");
+            } else {
+                $docsigned = $obj->to_pdf_file_s();
+                if ($docsigned === false)
+                    fwrite(STDERR, "could not sign the document");
+                else
+                    echo $docsigned;
+            }
         }
     }
 }

--- a/pdfsigni.php
+++ b/pdfsigni.php
@@ -76,12 +76,15 @@ else {
 
             // Set the image appearance and the certificate file
             $obj->set_signature_appearance(0, [ $p_x, $p_y, $p_x + $i_w, $p_y + $i_h ], $image);
-            $obj->set_signature_certificate($argv[3], $password);
-            $docsigned = $obj->to_pdf_file_s();
-            if ($docsigned === false)
-                fwrite(STDERR, "could not sign the document");
-            else
-                echo $docsigned;
+            if (!$obj->set_signature_certificate($argv[3], $password)) {
+                fwrite(STDERR, "the certificate is not valid");
+            } else {
+                $docsigned = $obj->to_pdf_file_s();
+                if ($docsigned === false)
+                    fwrite(STDERR, "could not sign the document");
+                else
+                    echo $docsigned;
+            }
         }
     }
 }


### PR DESCRIPTION
Affected Function acquire_structure (sapp/src/PDFUtilFnc.php)
I found PDF file with space in the version number, before \r\n
This caused PDF version checking to break.
I would like to suggest trimming the $pdf_version variable.

example, there is space after "2":
"%PDF-1.2 \r\n......"