### PR TITLE
Fix private key bug on windows

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -291,14 +291,11 @@ class PDFDoc extends Buffer {
         // First we read the certificate
         if (is_array($certfile)) {
             $certificate = $certfile;
+            $certificate["pkey"] = [$certificate["pkey"], $certpass];
 
             // If a password is provided, we'll try to decode the private key
-            $t_pkey = openssl_pkey_get_private($certificate["pkey"], $certpass);
-            if ($t_pkey === false)
+            if (openssl_pkey_get_private($certificate["pkey"]) === false)
                 return p_error("invalid private key");
-
-            openssl_pkey_export($t_pkey, $t_decpkey);
-            $certificate["pkey"] = $t_decpkey;
 
             // TODO: check the certificate
         } else {


### PR DESCRIPTION
Closes #48
@dealfonso seems like a bug on windows, i test this with xampp and Windows 10 64b
We can do
```php
$publicKeyFile = file_get_contents('cert.key');
$keyFile = file_get_contents('private.key');
$keyPassphrase = "password1234";
$keyData =[$keyFile, $keyPassphrase];

// sign 
openssl_pkcs7_sign(
    $file_msg,
    $file_sign,
    $publicKeyFile,
    $keyData, /// [private key, password]
    array(),
    PKCS7_BINARY
);
```