### PR TITLE
fix TypeError on all signatures reading

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -1073,8 +1073,8 @@ class PDFDoc extends Buffer {
                    $cert
                 );
 
-                $signature += openssl_x509_parse($cert[0]);
-            } catch (\Exception $e) {}
+                $signature += openssl_x509_parse($cert[0] ?? '') ?: [];
+            } catch (\Throwable $e) {}
 
             $signatures[] = $signature;
         }


### PR DESCRIPTION
Helps to get signatures count without errors
In some signatures `openssl_pkcs7_read` does not work, 
`TODO`: find the real problem
>Produces the typeError above: [sample01.pdf](https://github.com/dealfonso/sapp/files/12841165/sample01.pdf)

https://github.com/dealfonso/sapp/blob/f2ec4b038e5e8d605ed7054d1d9695fa25c388d1/src/PDFDoc.php#L1064-L1074