### PR TITLE
Adds support for intermediate certificates in PDF document signing

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -282,7 +282,7 @@ class PDFDoc extends Buffer {
     
     /**
      * Function that stores the certificate to use, when signing the document
-     * @param certfile a file that contains a user certificate in pkcs12 format, or an array [ 'cert' => <cert.pem>, 'pkey' => <key.pem> ]
+     * @param certfile a file that contains a user certificate in pkcs12 format, or an array [ 'cert' => <cert.pem>, 'pkey' => <key.pem>, 'extracerts' => [<key.pem>] ]
      *                 that would be the output of openssl_pkcs12_read
      * @param password the password to read the private key
      * @return valid true if the certificate can be used to sign the document, false otherwise
@@ -799,7 +799,8 @@ class PDFDoc extends Buffer {
 
             // Calculate the signature and remove the temporary file
             $certificate = $_signature->get_certificate();
-            $signature_contents = PDFUtilFnc::calculate_pkcs7_signature($temp_filename, $certificate['cert'], $certificate['pkey'], __TMP_FOLDER);
+            $extracerts = (array_key_exists('extracerts', $certificate)) ? $certificate['extracerts'] : null;
+            $signature_contents = PDFUtilFnc::calculate_pkcs7_signature($temp_filename, $certificate['cert'], $certificate['pkey'], __TMP_FOLDER, $extracerts);
             unlink($temp_filename);
 
             // Then restore the contents field


### PR DESCRIPTION
Implements the ability to include intermediate certificates for establishing the trust chain when signing PDF documents.
Supports the default behaviour of *.p12 files containing intermediate certificates in extracerts attribute.

I had the following files:
- certificate.cer - my certificate
- private.key - private key for the certificate
- intermediate.cer - intermediate certificate needed for establishing the trust chain to the trusted root certificate

I created a p12 file with the following command:
```
openssl pkcs12 -export -out your_combined_cert.p12 -inkey private.key -in certificate.cer -certfile intermediate.cer
```

When reading the p12 file the array stored PDFDoc::$_certificate contains an additional attribute `extracerts` which contains the intermediate certificate.

With these changes the `extracerts` will be taken into account.