### PR TITLE
Fix page count check

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -1115,7 +1115,7 @@ class PDFDoc extends Buffer {
             if ($imagesize === false) {
                 return p_warning("failed to open the image $image");
             }
-            if (($page_to_appear < 0) || ($page_to_appear > $this->get_page_count())) {
+            if (($page_to_appear < 0) || ($page_to_appear > $this->get_page_count() - 1)) {
                 return p_error("invalid page number");
             }
             $pagesize = $this->get_page_size($page_to_appear);


### PR DESCRIPTION
Parameter $page_to_appear is zero based. The get_page_count method returns the number of pages starting with 1. The if statement does not trigger an error if 1 is provided on a document with 1 page. Reducing the count by 1 solves the issue.