### PR TITLE
Add signature options feature

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -316,30 +316,29 @@ class PDFDoc extends Buffer {
     /**
      * Function that stores the certificate info to use, when signing the document
      *
-     * @param options an associative array with the following keys: Name, Reason, Location, ContactInfo
+     * @param name refers to the identity of the signer
+     * @param reason describes the purpose or justification for applying the digital signature
+     * @param location indicates the geographical location where the digital signature was applied
+     * @param contact_info provides contact information associated with the signer
      * @return void
      */
-    public function set_signature_options($options): void
+    public function set_signature_options($name = null, $reason = null, $location = null, $contact_info = null): void
     {
-        if(!is_array($options)){
-            return;
+        // Update the signature options, but only with allowed fields
+        if($name){
+            $this->_certificate_options['Name'] = new PDFValueString($name);
         }
 
-        // Update the certificate info, but only with allowed fields
-        if(array_key_exists('Name', $options) && $options['Name']){
-            $this->_certificate_options['Name'] = new PDFValueString($options['Name']);
+        if($reason){
+            $this->_certificate_options['Reason'] = new PDFValueString($reason);
         }
 
-        if(array_key_exists('Reason', $options) && $options['Reason']){
-            $this->_certificate_options['Reason'] = new PDFValueString($options['Reason']);
+        if($location){
+            $this->_certificate_options['Location'] = new PDFValueString($location);
         }
 
-        if(array_key_exists('Location', $options) && $options['Location']){
-            $this->_certificate_options['Location'] = new PDFValueString($options['Location']);
-        }
-
-        if(array_key_exists('ContactInfo', $options) && $options['ContactInfo']){
-            $this->_certificate_options['ContactInfo'] = new PDFValueString($options['ContactInfo']);
+        if($contact_info){
+            $this->_certificate_options['ContactInfo'] = new PDFValueString($contact_info);
         }
     }
 
@@ -428,7 +427,6 @@ class PDFDoc extends Buffer {
         if ($this->_certificate !== null) {
             $signature = $this->create_object($this->_certificate_options, "ddn\sapp\PDFSignatureObject", false);
             //$signature = new PDFSignatureObject([]);
-            //$signature->set_metadata(reason: "Signature");
             $signature->set_certificate($this->_certificate);
 
             // Update the value to the annotation object

--- a/src/PDFSignatureObject.php
+++ b/src/PDFSignatureObject.php
@@ -67,8 +67,9 @@ class PDFSignatureObject extends PDFObject {
     /**
      * Constructs the object and sets the default values needed to sign
      * @param oid the oid for the object
+     * @param value the default values
      */
-    public function __construct($oid) {
+    public function __construct($oid, $value=null) {
         $this->_prev_content_size = 0;
         $this->_post_content_size = null;
         parent::__construct($oid, [
@@ -78,6 +79,7 @@ class PDFSignatureObject extends PDFObject {
             'ByteRange' => new PDFValueSimple(str_repeat(" ", __BYTERANGE_SIZE)),
             'Contents' => "<" . str_repeat("0", __SIGNATURE_MAX_LENGTH) . ">",
             'M' => new PDFValueString(timestamp_to_pdfdatestring()),
+            ...$value,
         ]);
     }
     /**


### PR DESCRIPTION
Developers can now add signature options (e.g., Name, Reason, Location, and ContactInfo) to a document's digital signature.

## How it works
```
// Create an array with the fields
$options = [
  'Name' => '*** Name of signer***',
  'Reason' => '*** Reason for signing ***',
  'Location' => '*** Geographical location where it was signed ***',
  'ContactInfo' => '*** contact information associated with the signer ***',
];

$certificate = [
  'cert' => $certificate,
  'pkey' => $private_key,
];

$content = file_get_contents('path/to/file.pdf');
$obj = PDFDoc::from_string($content);

$obj->set_signature_certificate($certificate);
$obj->set_signature_options($options); // Use this method to set the options

$signed = $obj->to_pdf_file_s();

file_put_contents('path/to/save/signed/file.pdf', $signed);
```