### PR TITLE
Global constants to class properties

### DIFF
--- a/pdfsign.php
+++ b/pdfsign.php
@@ -38,7 +38,7 @@ else {
 
         $file_content = file_get_contents($argv[1]);
         $obj = PDFDoc::from_string($file_content);
-        
+
         if ($obj === false)
             fwrite(STDERR, "failed to parse file " . $argv[1]);
         else {

--- a/pdfsigni.php
+++ b/pdfsigni.php
@@ -39,7 +39,7 @@ else {
 
         $file_content = file_get_contents($argv[1]);
         $obj = PDFDoc::from_string($file_content);
-        
+
         if ($obj === false)
             fwrite(STDERR, "failed to parse file " . $argv[1]);
         else {

--- a/pdfsignlts.php
+++ b/pdfsignlts.php
@@ -47,7 +47,7 @@ else {
             $tsa = trim(fgets(STDIN)) ?: "http://timestamp.digicert.com";
             system('stty echo');
             fwrite(STDERR, "\n");
-        }   
+        }
 
         $file_content = file_get_contents($argv[1]);
         $obj = PDFDoc::from_string($file_content);

--- a/pdfsigntsa.php
+++ b/pdfsigntsa.php
@@ -43,7 +43,7 @@ else {
             $tsa = trim(fgets(STDIN)) ?: "http://timestamp.digicert.com";
             system('stty echo');
             fwrite(STDERR, "\n");
-        }   
+        }
 
         $file_content = file_get_contents($argv[1]);
         $obj = PDFDoc::from_string($file_content);

--- a/pdfsignx.php
+++ b/pdfsignx.php
@@ -39,7 +39,7 @@ else {
 
         $file_content = file_get_contents($argv[1]);
         $obj = PDFDoc::from_string($file_content);
-        
+
         if ($obj === false)
             fwrite(STDERR, "failed to parse file " . $argv[1]);
         else {

--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -23,6 +23,7 @@ namespace ddn\sapp;
 
 use ddn\sapp\PDFBaseDoc;
 use ddn\sapp\PDFBaseObject;
+use ddn\sapp\PDFSignatureObject;
 use ddn\sapp\pdfvalue\PDFValueObject;
 use ddn\sapp\pdfvalue\PDFValueList;
 use ddn\sapp\pdfvalue\PDFValueReference;
@@ -466,9 +467,9 @@ class PDFDoc extends Buffer {
             $len = strlen($res);
             p_debug("     Signature Length is \"$len\" Bytes");
             p_debug("     ########## FINISHED SIGNATURE LENGTH CHECK #########\n\n");
-            define('__SIGNATURE_MAX_LENGTH', $len);
+            PDFSignatureObject::$__SIGNATURE_MAX_LENGTH = $len;
 
-            $signature = $this->create_object([], "ddn\sapp\PDFSignatureObject", false);
+            $signature = $this->create_object([], PDFSignatureObject::class, false);
             //$signature = new PDFSignatureObject([]);
             $signature->set_metadata($this->_metadata_name, $this->_metadata_reason, $this->_metadata_location, $this->_metadata_contact_info);
             $signature->set_certificate($this->_certificate);
@@ -880,7 +881,7 @@ class PDFDoc extends Buffer {
             $cms->signature_data['ltv'] = $_signature->get_ltv();
             $cms->signature_data['tsa'] = $_signature->get_tsa();
             $signature_contents = $cms->pkcs7_sign($_signable_document->get_raw());
-            $signature_contents = str_pad($signature_contents, __SIGNATURE_MAX_LENGTH, '0');
+            //$signature_contents = str_pad($signature_contents, strlen($signature_contents), '0');
 
             // Then restore the contents field
             $_signature["Contents"] = new PDFValueHexString($signature_contents);

--- a/src/PDFSignatureObject.php
+++ b/src/PDFSignatureObject.php
@@ -20,7 +20,7 @@
 */
 
 namespace ddn\sapp;
-    
+
 use ddn\sapp\PDFObject;
 use ddn\sapp\pdfvalue\PDFValue;
 use ddn\sapp\pdfvalue\PDFValueHexString;
@@ -32,19 +32,16 @@ use ddn\sapp\pdfvalue\PDFValueString;
 use ddn\sapp\pdfvalue\PDFValueType;
 use function ddn\sapp\helpers\timestamp_to_pdfdatestring;
 
-// The maximum signature length, needed to create a placeholder to calculate the range of bytes
-// that will cover the signature.
-if (!defined('__SIGNATURE_MAX_LENGTH'))
-    //define('__SIGNATURE_MAX_LENGTH', 11742);
-    define('__SIGNATURE_MAX_LENGTH', 27742);
-
-// The maximum expected length of the byte range, used to create a placeholder while the size
-// is not known. 68 digits enable 20 digits for the size of the document
-if (!defined('__BYTERANGE_SIZE'))
-    define('__BYTERANGE_SIZE', 68);
-
 // This is an special object that has a set of fields
 class PDFSignatureObject extends PDFObject {
+    // The maximum signature length, needed to create a placeholder to calculate the range of bytes
+    // that will cover the signature.
+    public static $__SIGNATURE_MAX_LENGTH = 27742;
+
+    // The maximum expected length of the byte range, used to create a placeholder while the size
+    // is not known. 68 digits enable 20 digits for the size of the document
+    public static $__BYTERANGE_SIZE = 68;
+
     protected $_prev_content_size = 0;
     protected $_post_content_size = null;
 
@@ -90,8 +87,8 @@ class PDFSignatureObject extends PDFObject {
             'Filter' => "/Adobe.PPKLite",
             'Type' => "/Sig",
             'SubFilter' => "/adbe.pkcs7.detached",
-            'ByteRange' => new PDFValueSimple(str_repeat(" ", __BYTERANGE_SIZE)),
-            'Contents' => "<" . str_repeat("0", __SIGNATURE_MAX_LENGTH) . ">",
+            'ByteRange' => new PDFValueSimple(str_repeat(" ", self::$__BYTERANGE_SIZE)),
+            'Contents' => "<" . str_repeat("0", self::$__SIGNATURE_MAX_LENGTH) . ">",
             'M' => new PDFValueString(timestamp_to_pdfdatestring()),
         ]);
     }
@@ -144,7 +141,7 @@ class PDFSignatureObject extends PDFObject {
     public function to_pdf_entry() {
         $signature_size = strlen(parent::to_pdf_entry());
         $offset = $this->get_signature_marker_offset();
-        $starting_second_part = $this->_prev_content_size + $offset + __SIGNATURE_MAX_LENGTH + 2;
+        $starting_second_part = $this->_prev_content_size + $offset + self::$__SIGNATURE_MAX_LENGTH + 2;
 
         $contents_size = strlen("" . $this->_value['Contents']);
 
@@ -154,7 +151,7 @@ class PDFSignatureObject extends PDFObject {
             ($this->_post_content_size!==null?$this->_post_content_size + ($signature_size - $contents_size - $offset):0) . " ]";
 
         $this->_value['ByteRange'] =
-            new PDFValueSimple($byterange_str . str_repeat(" ", __BYTERANGE_SIZE - strlen($byterange_str) + 1)
+            new PDFValueSimple($byterange_str . str_repeat(" ", self::$__BYTERANGE_SIZE - strlen($byterange_str) + 1)
         );
 
         return parent::to_pdf_entry();


### PR DESCRIPTION
- Closes #74

>causes a error constant already defined when using the library to sign multiple times a document. The constant is created during the first sign. I suppose that this __SIGNATURE_MAX_LENGTH depends of signature_data parameters so should be move to a protected parameter instead of a global constant

