### PR TITLE
Update x509.php to parse ASN1_GENERALIZEDTIME 

### DIFF
--- a/src/helpers/x509.php
+++ b/src/helpers/x509.php
@@ -491,12 +491,12 @@ class x509 {
           unset($curr[$key]);
           continue;
         }
-        if($value['type'] == '17' && !array_key_exists('thisUpdate', $curr)) {
+        if(($value['type'] == '17' || $value['type'] == '18') && !array_key_exists('thisUpdate', $curr)) {
           $curr['thisUpdate']=hex2bin($value['value_hex']);
           unset($curr[$key]);
           continue;
         }
-        if($value['type'] == '17' && !array_key_exists('nextUpdate', $curr)) {
+        if(($value['type'] == '17' || $value['type'] == '18') && !array_key_exists('nextUpdate', $curr)) {
           $curr['nextUpdate']=hex2bin($value['value_hex']);
           unset($curr[$key]);
           continue;
@@ -612,11 +612,13 @@ class x509 {
       $differ=array_diff_key($arrModel['TBSCertList'],$crl['TBSCertList']);
       if(count($differ) > 0) {
         foreach($differ as $key=>$val) {
+          // TODO?
         }
         return false;
       }
     } else {
       foreach($differ as $key=>$val) {
+        // TODO?
       }
       return false;
     }


### PR DESCRIPTION
For very long nextUpdate CRL could contain ASN1_GENERALIZEDTIME instead of ASN1_UTCTIME.
Should we take that into account when parsing the x509 crl file?
Cheers,
Jacq