### PR TITLE
Charset decode on metadata

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -363,12 +363,27 @@ class PDFDoc extends Buffer {
      * @param $contact
      * @return void
      */
-    public function set_metadata_props($name = null, $reason = null, $location = null, $contact = null)
+    public function set_metadata_props($name = null, $reason = null, $location = null, $contact = null, $encoding = 'ISO-8859-1')
     {
-        $this->_metadata_name = $name;
-        $this->_metadata_reason = $reason;
-        $this->_metadata_location = $location;
-        $this->_metadata_contact_info = $contact;
+        $this->_metadata_name = $this->charset_encode($name, $encoding);
+        $this->_metadata_reason = $this->charset_encode($reason, $encoding);
+        $this->_metadata_location = $this->charset_encode($location, $encoding);
+        $this->_metadata_contact_info = $this->charset_encode($contact, $encoding);
+    }
+
+    private function charset_encode($string, $to)
+    {
+        if (!is_string($string) || !function_exists('mb_detect_encoding')) {
+            return $string;
+        }
+
+        $encoding = mb_detect_encoding($string, mb_list_encodings(), true);
+
+        if ($encoding !== $to) {
+            $string = mb_convert_encoding($string, $to, $encoding);
+        }
+
+        return $string;
     }
 
     /**


### PR DESCRIPTION
Closes #78
> I am testing the signature -> set_metadata_props feature , but it's not show correctly.
My signing reason is "ทดสอบ"

![image](https://github.com/user-attachments/assets/830b977f-bf36-4bca-a1e7-49cc866163d0)
![image](https://github.com/user-attachments/assets/0806a677-00ee-48db-b575-9a0626f717a6)

To ensure that Thai characters are displayed correctly in the metadata (such as the "Reason" field) of a PDF file, you must ensure that the correct encoding (UTF-16BE for Unicode) is used when setting the values ​​of these fields.

The `\xFE\xFF` prefix is ​​added to UTF-16BE strings to indicate that they are in this encoding.