### PR TITLE
Signature appearance without name

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -264,12 +264,14 @@ class PDFDoc extends Buffer {
      * @param page the page (zero based) in which the signature will appear
      * @param rect the rectangle (in page-based coordinates) where the signature will appear in that page
      * @param imagefilename an image file name (or an image in a buffer, with symbol '@' prepended) that will be put inside the rect
+     * @param string|null $name the name of the signature (if not set, a random name will be used)
      */
-    public function set_signature_appearance($page_to_appear = 0, $rect_to_appear = [0, 0, 0, 0], $imagefilename = null) {
+    public function set_signature_appearance($page_to_appear = 0, $rect_to_appear = [0, 0, 0, 0], $imagefilename = null, $name = null) {
         $this->_appearance = [
             "page" => $page_to_appear,
             "rect" => $rect_to_appear,
-            "image" => $imagefilename
+            "image" => $imagefilename,
+            "name" => $name,
         ];
     }
 
@@ -448,7 +450,7 @@ class PDFDoc extends Buffer {
                 "Subtype" => "/Widget",
                 "FT" => "/Sig",
                 "V" => new PDFValueString(""),
-                "T" => new PDFValueString('Signature' . get_random_string()),
+                "T" => new PDFValueString('Signature' . $this->_appearance['name'] ?? get_random_string()),
                 "P" => new PDFValueReference($page_obj->get_oid()),
                 "Rect" => $recttoappear,
                 "F" => 132  // TODO: check this value

--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -450,7 +450,7 @@ class PDFDoc extends Buffer {
                 "Subtype" => "/Widget",
                 "FT" => "/Sig",
                 "V" => new PDFValueString(""),
-                "T" => new PDFValueString('Signature' . $this->_appearance['name'] ?? get_random_string()),
+                "T" => new PDFValueString(($this->_appearance['name'] ?? ('Signature' . get_random_string()))),
                 "P" => new PDFValueReference($page_obj->get_oid()),
                 "Rect" => $recttoappear,
                 "F" => 132  // TODO: check this value


### PR DESCRIPTION
In ddn/sapp v1.5.2, an option was added ([#90](https://github.com/dealfonso/sapp/pull/90)) to allow signature boxes with a specific name. However, the original implementation had an operator precedence issue:

`"Signature" . $this->_appearance['name'] ?? get_random_string()`

This caused the fallback for generating a random string to never be used, so when creating multiple boxes without a specified name, they ended up with the same name, leading to conflicts.

This PR fixes the logic by properly applying the fallback:

`"T" => new PDFValueString($this->_appearance['name'] ?? ('Signature' . get_random_string())),`

Now:
If a name is provided → use it.
If not → use "Signature" plus a random string.