### PR TITLE
Update signature appearance name parameter

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -450,7 +450,7 @@ class PDFDoc extends Buffer {
                 "Subtype" => "/Widget",
                 "FT" => "/Sig",
                 "V" => new PDFValueString(""),
-                "T" => new PDFValueString('Signature' . $this->_appearance['name'] ?? get_random_string()),
+                "T" => new PDFValueString($this->_appearance['name'] ?? ('Signature' . get_random_string())),
                 "P" => new PDFValueReference($page_obj->get_oid()),
                 "Rect" => $recttoappear,
                 "F" => 132  // TODO: check this value


### PR DESCRIPTION
In ddn/sapp v1.5.2, an option was added ([#90](https://github.com/dealfonso/sapp/pull/90)) to allow signature boxes with a specific name. However, the original implementation had an operator precedence issue:

`"Signature" . $this->_appearance['name'] ?? get_random_string()`

This caused the fallback for generating a random string to never be used, so when creating multiple boxes without a specified name, they ended up with the same name, leading to conflicts.

Now:
If a name is provided → use it.
If not → use "Signature" plus a random string.