### PR TITLE
Fix pdf objs regex - some PDFs don’t have whitespace after obj string

### DIFF
--- a/src/PDFUtilFnc.php
+++ b/src/PDFUtilFnc.php
@@ -578,7 +578,7 @@ class PDFUtilFnc {
      * Function that parses an object 
      */
     public static function object_from_string(&$buffer, $expected_obj_id, $offset = 0, &$offset_end = 0) {
-        if (preg_match('/([0-9]+)\s+([0-9]+)\s+obj(\s+)/ms', $buffer, $matches, 0, $offset) !== 1) {
+        if (preg_match('/([0-9]+)\s+([0-9]+)\s+obj\b/ms', $buffer, $matches, 0, $offset) !== 1) {
             // p_debug_var(substr($buffer))
             return p_error("object is not valid: $expected_obj_id");
         }


### PR DESCRIPTION
Compressed PDFs do not usually have that space after obj:  [example.pdf](https://github.com/user-attachments/files/22009123/nota.pdf)

## DEMO
**Before:** `/([0-9]+)\s+([0-9]+)\s+obj(\s+)/ms` https://regex101.com/r/UuDY19/1
**After:** `/([0-9]+)\s+([0-9]+)\s+obj\b/ms` https://regex101.com/r/COtjhz/1