### PR TITLE
make sure that the Fields field is a list in AcroForm

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -586,7 +586,15 @@ class PDFDoc extends Buffer {
         $acroform["SigFlags"] = 3;
         if (!isset($acroform['Fields']))
             $acroform['Fields'] = new PDFValueList();
-
+        else {
+            // Found some cases in which Fields is not a list, so we convert it into a list
+            if (!($acroform['Fields'] instanceof PDFValueList)) {
+                $val = $acroform['Fields'];
+                $acroform['Fields'] = new PDFValueList();
+                $acroform['Fields']->push($val);
+            }
+        }
+        
         // Add the annotation object to the interactive form
         if (!$acroform['Fields']->push(new PDFValueReference($annotation_object->get_oid()))) {
             return p_error("could not create the signature field");


### PR DESCRIPTION
The field `Fields` in an `AcroForm` is not mandatory to be a list. When creating a new signature in the document, we need to make sure that it is a list so that it is possible to push the new field.

This bug was detected in issue #108 