### PR TITLE
Fix ObjStm index parsing by using whitespace-tolerant splitting

### DIFF
--- a/src/PDFUtilFnc.php
+++ b/src/PDFUtilFnc.php
@@ -501,7 +501,7 @@ class PDFUtilFnc {
 
         $stream = $objstm->get_stream(false);
         $index = substr($stream, 0, $First);
-        $index = explode(" ", trim($index));
+        $index = preg_split('/\s+/', trim($index));
         $stream = substr($stream, $First);
 
         if (count($index) % 2 !== 0)


### PR DESCRIPTION
This PR fixes an issue when parsing Object Streams (`/ObjStm`).
The current implementation uses:
https://github.com/dealfonso/sapp/blob/d6f6c64df6bc4e2439cf45f457a82eaf9ef7c342/src/PDFUtilFnc.php#L504

This assumes that the index entries inside an Object Stream are always separated by a single space.
However, according to the PDF specification, the index can contain arbitrary whitespace, including:

- multiple spaces
- line breaks (`\n`, `\r`, `\r\n`)
- tabs (`\t`)
- combinations of the above

Because of this, explode(" ", ...) may generate empty entries or incorrectly split the index, resulting in an odd number of tokens and triggering the error:
```php
"invalid index for object stream $objstm_oid"
```
This safely splits on any sequence of whitespace, ensuring a valid even-length array matching:
```
[ objId_0, offset_0, objId_1, offset_1, ... ]
```

Closes #117
Closes #118