### PR TITLE
Fix invalid stream ending

### DIFF
--- a/src/PDFObjectParser.php
+++ b/src/PDFObjectParser.php
@@ -426,11 +426,11 @@
             while ($this->nextchar() !== false) {
                 if ($this->_n === 'e') {
                     // Possible "endstream" or "endobj"
-                    if ($this->_buffer->substratpos(9) === "endstream") {
+                    if (preg_match('/endstream\s$/', $this->_buffer->substratpos(10))) {
                         $stream_content .= $this->_c;
                         $this->nextchar();
                         break;
-                    } else if ($this->_buffer->substratpos(6) === "endobj") {
+                    } else if (preg_match('/endobj\s$/', $this->_buffer->substratpos(7))) {
                         $stream_content .= $this->_c;
                         $this->nextchar();
                         break;

--- a/src/PDFObjectParser.php
+++ b/src/PDFObjectParser.php
@@ -428,9 +428,11 @@
                     // Possible "endstream" or "endobj"
                     if ($this->_buffer->substratpos(9) === "endstream") {
                         $stream_content .= $this->_c;
+                        $this->nextchar();
                         break;
                     } else if ($this->_buffer->substratpos(6) === "endobj") {
                         $stream_content .= $this->_c;
+                        $this->nextchar();
                         break;
                     } else {
                         $stream_content .= $this->_c;


### PR DESCRIPTION
> this is more a problem on reading the stream when the size is known

Alternative for #120, ~without guessing `endstream`~ (https://github.com/dealfonso/sapp/pull/120#issuecomment-3611185520, https://github.com/dealfonso/sapp/pull/120#issuecomment-3612312953)


This PR adds support for PDF streams where the end tokens(like `endstream`) appear immediately after the stream data, without any whitespace or line break.
Some PDF generators embed metadata blocks that end like this:

```xml
<?xpacket end="w"?>endstream
```
In this case, the parser previously failed to recognize the `endstream` token because it expected a whitespace separator before it. As a result, the tokenization would break and parsing of the stream would fail.

- Closes #119