### PR TITLE
Signature Max Length & Extracerts Format

### DIFF
--- a/src/PDFDoc.php
+++ b/src/PDFDoc.php
@@ -310,9 +310,8 @@ class PDFDoc extends Buffer {
                 return p_error("private key doesn't corresponds to certificate");
 
             if (is_string($certificate['extracerts'] ?? null)) {
-                $certificate['extracerts'] = array_filter(explode("-----END CERTIFICATE-----\n", $certificate['extracerts']));
-                foreach ($certificate['extracerts'] as &$extracerts)
-                    $extracerts = $extracerts . "-----END CERTIFICATE-----\n";
+                preg_match_all("/-----BEGIN CERTIFICATE-----(.*?)-----END CERTIFICATE-----/s", $certificate['extracerts'], $matches);
+                $certificate['extracerts'] = $matches[0];
             }
         } else {
             $certfilecontent = file_get_contents($certfile);

--- a/src/PDFSignatureObject.php
+++ b/src/PDFSignatureObject.php
@@ -36,7 +36,7 @@ use function ddn\sapp\helpers\timestamp_to_pdfdatestring;
 class PDFSignatureObject extends PDFObject {
     // The maximum signature length, needed to create a placeholder to calculate the range of bytes
     // that will cover the signature.
-    public static $__SIGNATURE_MAX_LENGTH = 27742;
+    public static $__SIGNATURE_MAX_LENGTH = 38000;
 
     // The maximum expected length of the byte range, used to create a placeholder while the size
     // is not known. 68 digits enable 20 digits for the size of the document


### PR DESCRIPTION
Increase signature max length to 38000.
Replace extracerts "explode" by "preg_match_all".