### PR TITLE
Implement XRefStm handling in PDFUtilFnc

### DIFF
--- a/src/PDFUtilFnc.php
+++ b/src/PDFUtilFnc.php
@@ -347,6 +347,16 @@ class PDFUtilFnc {
 
         // Get the trailer object
         $trailer_obj = PDFUtilFnc::get_trailer($_buffer, $trailer_pos);
+        if (isset($trailer_obj['XRefStm'])) {
+            $xrefstm_pos = $trailer_obj['XRefStm']->get_int();
+            [ $xrefstm_table ] = PDFUtilFnc::get_xref_1_5($_buffer, $xrefstm_pos, $depth);
+
+            foreach ($xrefstm_table as $oid => $val) {
+                if (!isset($xref_table[$oid])) {
+                    $xref_table[$oid] = $val;
+                }
+            }
+        }
 
         // If there exists a previous xref (for incremental PDFs), get it and merge the objects that do not exist in the current xref table
         if (isset($trailer_obj['Prev'])) {


### PR DESCRIPTION
Added handling for `XRefStm` in PDF trailer processing.
[object-streams.html#cross-reference-streams](https://qpdf.readthedocs.io/en/latest/object-streams.html#cross-reference-streams)
```
trailer
<</Size 23/Root 1 0 R/Info 9 0 R/ID[<CC624E32F9811843A1DC762908A2F2B3><CC624E32F9811843A1DC762908A2F2B3>] >>
startxref
27721
%%EOF
xref
0 0
trailer
<</Size 23/Root 1 0 R/Info 9 0 R
/ID[<CC624E32F9811843A1DC762908A2F2B3><CC624E32F9811843A1DC762908A2F2B3>] 
/Prev 27721/XRefStm 27438>>
startxref
28337
%%EOF
```
I prefer that they check it thoroughly before merging; it works for me, but I don't know if it's the best approach.
I had to send it to production and it works for me