### PR TITLE
Use DateTime for timestamp conversion from 'yymmddhhiiss'

### DIFF
--- a/src/helpers/asn1.php
+++ b/src/helpers/asn1.php
@@ -233,7 +233,7 @@ class asn1 {
           $time = $params[0]; //yymmddhhiiss
           $oldTz = date_default_timezone_get();
           date_default_timezone_set("UTC");
-          $time = date("ymdHis", $time);
+          $time = \DateTime::createFromFormat('ymdHis', $time)->getTimestamp();
           date_default_timezone_set($oldTz);
           $val = bin2hex($time."Z");
         }

--- a/src/helpers/asn1.php
+++ b/src/helpers/asn1.php
@@ -230,11 +230,8 @@ class asn1 {
           return $ret;
         }
         if($func == 'utime') {
-          $time = $params[0]; //yymmddhhiiss
-          $oldTz = date_default_timezone_get();
-          date_default_timezone_set("UTC");
-          $time = \DateTime::createFromFormat('ymdHis', $time)->getTimestamp();
-          date_default_timezone_set($oldTz);
+          $date = $params[0]; //yymmddhhiiss
+          $time = \DateTime::createFromFormat('ymdHis', $date, new \DateTimeZone('UTC'))->getTimestamp();
           $val = bin2hex($time."Z");
         }
         if($func == 'gtime') {


### PR DESCRIPTION
Closes #129

The `asn1::utime()` function in `src/helpers/asn1.php` expects a date with `yymmddhhiiss` format,
but `date()` 2nd arg expects Unix timestamp (`?int`) as input: 
`date(string $format, ?int $timestamp = null): string` [php.net/function.date.php](https://www.php.net/manual/en/function.date.php) 
```php
if($func == 'utime') {
    $time = $params[0]; //yymmddhhiiss
    $oldTz = date_default_timezone_get();
    date_default_timezone_set("UTC");
    $time = date("ymdHis", $time);  // <-- Expects $time to be Unix timestamp, gets yymmddhhiiss string
    date_default_timezone_set($oldTz);
    $val = bin2hex($time."Z");
}
```

https://github.com/dealfonso/sapp/blob/2e8a56c33b77afcf3f6db86a0fb9926c7d8f15da/src/helpers/CMS.php#L479
https://github.com/dealfonso/sapp/blob/2e8a56c33b77afcf3f6db86a0fb9926c7d8f15da/src/helpers/asn1.php#L233-L236