### PR TITLE
Fix regex pattern for trailer extraction

### DIFF
--- a/src/PDFUtilFnc.php
+++ b/src/PDFUtilFnc.php
@@ -41,7 +41,7 @@ class PDFUtilFnc {
 
     public static function get_trailer(&$_buffer, $trailer_pos) {
         // Search for the trailer structure
-        if (preg_match('/trailer\s+(.*)\s+startxref/ms', $_buffer, $matches, 0, $trailer_pos) !== 1)
+        if (preg_match('/trailer\s*(.*)\s+startxref/ms', $_buffer, $matches, 0, $trailer_pos) !== 1)
             return p_error("trailer not found");
 
         $trailer_str = $matches[1];

--- a/src/PDFUtilFnc.php
+++ b/src/PDFUtilFnc.php
@@ -41,7 +41,7 @@ class PDFUtilFnc {
 
     public static function get_trailer(&$_buffer, $trailer_pos) {
         // Search for the trailer structure
-        if (preg_match('/trailer\s*(.*)\s+startxref/ms', $_buffer, $matches, 0, $trailer_pos) !== 1)
+        if (preg_match('/\btrailer\b\s*(.*)\s*\bstartxref\b/ms', $_buffer, $matches, 0, $trailer_pos) !== 1)
             return p_error("trailer not found");
 
         $trailer_str = $matches[1];


### PR DESCRIPTION
Current, works on:
```
trailer
<<
/Info 66 0 R
/Root 1 0 R
/Size 83
/ID [<6275CA013C49502DE51CB35AB6BFADAB> <B6CBCF3E17113BA70B60D37B78AAC32C>]
/Prev 1289403
>>
startxref
1318954
%%EOF
```
But fails on:
```
trailer<</Size 29 /Root 1 0 R /Info 3 0 R /ID [<b614...><7c583...>]>>
startxref
99378
%%EOF
```
maybe 
```php
'/\btrailer\b\s*(<<.*?>>)\s*\bstartxref\b/ms'
```